### PR TITLE
Fix elements distributed into an iron-pages inside another component in Safari 11

### DIFF
--- a/iron-pages.html
+++ b/iron-pages.html
@@ -44,7 +44,7 @@ Example:
         display: block;
       }
 
-      :host > ::slotted(:not(.iron-selected)) {
+      :host > ::slotted(:not(slot):not(.iron-selected)) {
         display: none !important;
       }
     </style>

--- a/iron-pages.html
+++ b/iron-pages.html
@@ -44,7 +44,7 @@ Example:
         display: block;
       }
 
-      :host > ::slotted(:not(slot):not(.iron-selected)) {
+      :host > ::slotted(:not(.iron-selected)) {
         display: none !important;
       }
     </style>

--- a/test/index.html
+++ b/test/index.html
@@ -26,6 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'basic.html?wc-shadydom=true&wc-ce=true',
         'attr-for-selected.html?dom=shadow',
         'attr-for-selected.html?wc-shadydom=true&wc-ce=true',
+        'nested.html',
         'nested.html?dom=shadow',
         'nested.html?wc-shadydom=true&wc-ce=true',
       ]);

--- a/test/index.html
+++ b/test/index.html
@@ -26,6 +26,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'basic.html?wc-shadydom=true&wc-ce=true',
         'attr-for-selected.html?dom=shadow',
         'attr-for-selected.html?wc-shadydom=true&wc-ce=true'
+        'nested.html?dom=shadow',
+        'nested.html?wc-shadydom=true&wc-ce=true',
       ]);
 
     </script>

--- a/test/index.html
+++ b/test/index.html
@@ -25,7 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'basic.html?dom=shadow',
         'basic.html?wc-shadydom=true&wc-ce=true',
         'attr-for-selected.html?dom=shadow',
-        'attr-for-selected.html?wc-shadydom=true&wc-ce=true'
+        'attr-for-selected.html?wc-shadydom=true&wc-ce=true',
         'nested.html?dom=shadow',
         'nested.html?wc-shadydom=true&wc-ce=true',
       ]);

--- a/test/index.html
+++ b/test/index.html
@@ -26,7 +26,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'basic.html?wc-shadydom=true&wc-ce=true',
         'attr-for-selected.html?dom=shadow',
         'attr-for-selected.html?wc-shadydom=true&wc-ce=true',
-        'nested.html',
         'nested.html?dom=shadow',
         'nested.html?wc-shadydom=true&wc-ce=true',
       ]);

--- a/test/nested-pages.html
+++ b/test/nested-pages.html
@@ -12,18 +12,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="nested-pages">
   <template>
     <h1>header</h1>
-    <iron-pages selected="[[selected]]" on-iron-items-changed="refire">
+    <iron-pages selected="0" on-iron-items-changed="refire">
       <slot></slot>
     </iron-pages>
   </template>
   <script>
     Polymer({
       is: 'nested-pages',
-      properties: {
-        selected: {
-          type: Number,
-        },
-      },
       refire: function(e, detail) {
         this.fire('iron-items-changed', e)
       }

--- a/test/nested-pages.html
+++ b/test/nested-pages.html
@@ -12,13 +12,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="nested-pages">
   <template>
     <h1>header</h1>
-    <iron-pages selected="0" on-iron-items-changed="refire" on-selected-item-changed="reselect">
+    <iron-pages selected="{{selected}}" on-iron-items-changed="refire" on-selected-item-changed="reselect">
       <slot></slot>
     </iron-pages>
   </template>
   <script>
     Polymer({
       is: 'nested-pages',
+      properties: {
+        selected: {
+          type: Number,
+          value: 0,
+        },
+      },  
       refire: function(e, detail) {
         this.items = e.target.items
         this.fire('iron-items-changed', e)

--- a/test/nested-pages.html
+++ b/test/nested-pages.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="nested-pages">
   <template>
     <h1>header</h1>
-    <iron-pages selected="0" on-iron-items-changed="refire">
+    <iron-pages selected="0" on-iron-items-changed="refire" on-selected-item-changed="reselect">
       <slot></slot>
     </iron-pages>
   </template>
@@ -20,8 +20,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer({
       is: 'nested-pages',
       refire: function(e, detail) {
+        this.items = e.target.items
         this.fire('iron-items-changed', e)
-      }
+      },
+      reselect: function(e, detail) {
+        this.selectedItem = e.target.selectedItem
+      },
     });
   </script>
 </dom-module>

--- a/test/nested-pages.html
+++ b/test/nested-pages.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../iron-pages.html">
+<dom-module id="nested-pages">
+  <template>
+    <h1>header</h1>
+    <iron-pages selected="[[selected]]" on-iron-items-changed="refire">
+      <slot></slot>
+    </iron-pages>
+  </template>
+  <script>
+    Polymer({
+      is: 'nested-pages',
+      properties: {
+        selected: {
+          type: Number,
+        },
+      },
+      refire: function(e, detail) {
+        this.fire('iron-items-changed', e)
+      }
+    });
+  </script>
+</dom-module>

--- a/test/nested.html
+++ b/test/nested.html
@@ -25,13 +25,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <dom-module id="nested-pages">
       <template>
         <h1>header</h1>
-        <iron-pages on-iron-items-changed="refire">
+        <iron-pages selected="[[selected]]" on-iron-items-changed="refire">
           <slot></slot>
         </iron-pages>
       </template>
       <script>
         Polymer({
           is: 'nested-pages',
+          properties: {
+            selected: {
+              type: Number,
+            },
+          },
           refire: function(e, detail) {
             this.fire('iron-items-changed', e)
           }
@@ -60,29 +65,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             pages = fixture('nested');
             pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
               pages.removeEventListener('iron-items-changed', onIronItemsChanged);
-
               pages.selected = 0;
               done();
             });
           });
 
-          test('selected value', function() {
-            assert.equal(pages.selected, '0');
-          });
-
-          test('selected item', function() {
-            assert.equal(pages.selectedItem, pages.items[0]);
-          });
-
           test('selected item is display:block and all others are display:none', function() {
-            pages.items.forEach(function(p) {
-              assert.equal(getComputedStyle(p).display, p == pages.selectedItem ? 'block' : 'none');
-              if (p == pages.selectedItem) {
+            for (i = 0; i < pages.children.length; i++) {
+              p = pages.children[i]
+              if (p.classList.contains('iron-selected')) {
+                assert.equal(getComputedStyle(p).display, 'block')
                 assert.isAbove(p.clientHeight, 0)
                 assert.isAbove(p.offsetHeight, 0)
                 assert.isAbove(p.scrollHeight, 0)
+              } else {
+                assert.equal(getComputedStyle(p).display, 'none')
+                assert.equaql(p.clientHeight, 0)
+                assert.equal(p.offsetHeight, 0)
+                assert.equal(p.scrollHeight, 0)
               }
-            });
+            }
           });
         });
 

--- a/test/nested.html
+++ b/test/nested.html
@@ -67,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 assert.equal(p.offsetHeight, 0)
                 assert.equal(p.scrollHeight, 0)
               }
-            });
+            }
           });
         });
       });

--- a/test/nested.html
+++ b/test/nested.html
@@ -25,10 +25,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <dom-module id="nested-pages">
       <template>
         <h1>header</h1>
-        <iron-pages selected="0">
+        <iron-pages on-iron-items-changed="refire">
           <slot></slot>
         </iron-pages>
       </template>
+      <script>
+        Polymer({
+          is: 'nested-pages',
+          refire: function(e, detail) {
+            this.fire('iron-items-changed', e)
+          }
+        });
+      </script>
     </dom-module>
 
     <test-fixture id="nested">
@@ -46,30 +54,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('nested', function() {
         var pages;
-
-        suite('defaults', function() {
+        
+        suite('set the selected attribute', function() {
           setup(function(done) {
             pages = fixture('nested');
-            done();
+            pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
+              pages.removeEventListener('iron-items-changed', onIronItemsChanged);
+
+              pages.selected = 0;
+              done();
+            });
+          });
+
+          test('selected value', function() {
+            assert.equal(pages.selected, '0');
+          });
+
+          test('selected item', function() {
+            assert.equal(pages.selectedItem, pages.items[0]);
           });
 
           test('selected item is display:block and all others are display:none', function() {
-            for (i = 0; i < pages.children.length; i++) {
-              var p = pages.children[i]
-              if (p.classList.contains('iron-selected')) {
-                assert.equal(getComputedStyle(p).display, 'block')
+            pages.items.forEach(function(p) {
+              assert.equal(getComputedStyle(p).display, p == pages.selectedItem ? 'block' : 'none');
+              if (p == pages.selectedItem) {
                 assert.isAbove(p.clientHeight, 0)
                 assert.isAbove(p.offsetHeight, 0)
                 assert.isAbove(p.scrollHeight, 0)
-              } else {
-                assert.equal(getComputedStyle(p).display, 'none');
-                assert.equal(p.clientHeight, 0)
-                assert.equal(p.offsetHeight, 0)
-                assert.equal(p.scrollHeight, 0)
               }
-            }
+            });
           });
         });
+
       });
 
     </script>

--- a/test/nested.html
+++ b/test/nested.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="./nested-pages.html">
     

--- a/test/nested.html
+++ b/test/nested.html
@@ -48,6 +48,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var pages;
 
         suite('defaults', function() {
+          setup(function(done) {
+            pages = fixture('nested');
+            done();
+          });
+
           test('selected item is display:block and all others are display:none', function() {
             pages.childNodes.forEach(function(p) {
               if (p.classList.contains('iron-selected')) {

--- a/test/nested.html
+++ b/test/nested.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+  <head>
+
+    <title>iron-pages-basic</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <link rel="import" href="../iron-pages.html">
+    
+  </head>
+  <body>
+    <dom-module id="nested-pages">
+      <template>
+        <h1>header</h1>
+        <iron-pages>
+          <slot></slot>
+        </iron-pages>
+      </template>
+    </dom-module>
+
+    <test-fixture id="basic">
+      <template>
+        <nested-pages>
+          <div id="page0">Page 0</div>
+          <div id="page1">Page 1</div>
+          <div id="page2">Page 2</div>
+          <div id="page3">Page 3</div>
+        </nested-pages>
+      </template>
+    </test-fixture>
+
+    <script>
+
+      suite('basic', function() {
+        var pages;
+
+        suite('defaults', function() {
+          setup(function(done) {
+            pages = fixture('basic');
+            pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
+              pages.removeEventListener('iron-items-changed', onIronItemsChanged);
+              done();
+            });
+          });
+
+          test('to nothing selected', function() {
+            assert.equal(pages.selected, undefined);
+          });
+
+          test('null activateEvent', function() {
+            // `activateEvent` is not a useful feature for iron-pages and it can interfere
+            // with ux; ensure iron-pages has cleared any default `activateEvent`
+            assert.equal(pages.activateEvent, null);
+          });
+
+          test('to iron-selected as selectedClass', function() {
+            assert.equal(pages.selectedClass, 'iron-selected');
+          });
+
+          test('as many items as children', function() {
+            assert.equal(pages.items.length, 4);
+          });
+
+          test('all pages are display:none', function() {
+            pages.items.forEach(function(p) {
+              assert.equal(getComputedStyle(p).display, 'none');
+            });
+          });
+        });
+
+        suite('set the selected attribute', function() {
+          setup(function(done) {
+            pages = fixture('basic');
+            pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
+              pages.removeEventListener('iron-items-changed', onIronItemsChanged);
+
+              pages.selected = 0;
+              done();
+            });
+          });
+
+          test('selected value', function() {
+            assert.equal(pages.selected, '0');
+          });
+
+          test('selected item', function() {
+            assert.equal(pages.selectedItem, pages.items[0]);
+          });
+
+          test('selected item is display:block and all others are display:none', function() {
+            pages.items.forEach(function(p) {
+              assert.equal(getComputedStyle(p).display, p == pages.selectedItem ? 'block' : 'none');
+            });
+          });
+        });
+
+      });
+
+    </script>
+
+  </body>
+</html>

--- a/test/nested.html
+++ b/test/nested.html
@@ -54,7 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
           test('selected item is display:block and all others are display:none', function() {
-            pages.childNodes.forEach(function(p) {
+            pages.children.forEach(function(p) {
               if (p.classList.contains('iron-selected')) {
                 assert.equal(getComputedStyle(p).display, 'block')
                 assert.isAbove(p.clientHeight, 0)

--- a/test/nested.html
+++ b/test/nested.html
@@ -25,7 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <dom-module id="nested-pages">
       <template>
         <h1>header</h1>
-        <iron-pages>
+        <iron-pages selected="0">
           <slot></slot>
         </iron-pages>
       </template>
@@ -50,68 +50,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suite('defaults', function() {
           setup(function(done) {
             pages = fixture('nested');
-            pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
-              pages.removeEventListener('iron-items-changed', onIronItemsChanged);
+            window.addEventListener('WebComponentsReady', function onReady() {
+              window.removeEventListener('WebComponentsReady', onReady);
               done();
             });
-          });
-
-          test('to nothing selected', function() {
-            assert.equal(pages.selected, undefined);
-          });
-
-          test('null activateEvent', function() {
-            // `activateEvent` is not a useful feature for iron-pages and it can interfere
-            // with ux; ensure iron-pages has cleared any default `activateEvent`
-            assert.equal(pages.activateEvent, null);
-          });
-
-          test('to iron-selected as selectedClass', function() {
-            assert.equal(pages.selectedClass, 'iron-selected');
-          });
-
-          test('as many items as children', function() {
-            assert.equal(pages.items.length, 4);
-          });
-
-          test('all pages are display:none', function() {
-            pages.items.forEach(function(p) {
-              assert.equal(getComputedStyle(p).display, 'none');
-            });
-          });
-        });
-
-        suite('set the selected attribute', function() {
-          setup(function(done) {
-            pages = fixture('basic');
-            pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
-              pages.removeEventListener('iron-items-changed', onIronItemsChanged);
-
-              pages.selected = 0;
-              done();
-            });
-          });
-
-          test('selected value', function() {
-            assert.equal(pages.selected, '0');
-          });
-
-          test('selected item', function() {
-            assert.equal(pages.selectedItem, pages.items[0]);
           });
 
           test('selected item is display:block and all others are display:none', function() {
-            pages.items.forEach(function(p) {
-              assert.equal(getComputedStyle(p).display, p == pages.selectedItem ? 'block' : 'none');
-              if (p == pages.selectedItem) {
+            pages.childNodes.forEach(function(p) {
+              if (p.classList.contains('iron-selected')) {
+                assert.equal(getComputedStyle(p).display, 'block')
                 assert.isAbove(p.clientHeight, 0)
                 assert.isAbove(p.offsetHeight, 0)
                 assert.isAbove(p.scrollHeight, 0)
+              } else {
+                assert.equal(getComputedStyle(p).display, 'none');
+                assert.equal(p.clientHeight, 0)
+                assert.equal(p.offsetHeight, 0)
+                assert.equal(p.scrollHeight, 0)
               }
             });
           });
         });
-
       });
 
     </script>

--- a/test/nested.html
+++ b/test/nested.html
@@ -44,7 +44,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             pages = fixture('nested');
             pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
               pages.removeEventListener('iron-items-changed', onIronItemsChanged);
-              pages.selected = 0;
               done();
             });
           });

--- a/test/nested.html
+++ b/test/nested.html
@@ -49,13 +49,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
           test('selected item is display:block and all others are display:none', function() {
+            var p = pages.selectedItem
+            assert.equal(getComputedStyle(p).display, 'block')
+            assert.isAbove(p.clientHeight, 0)
+            assert.isAbove(p.offsetHeight, 0)
+            assert.isAbove(p.scrollHeight, 0)
             pages.items.forEach(function(p) {
-              if (p == pages.selectedItem) {
-                assert.equal(getComputedStyle(p).display, 'block')
-                assert.isAbove(p.clientHeight, 0)
-                assert.isAbove(p.offsetHeight, 0)
-                assert.isAbove(p.scrollHeight, 0)
-              } else {
+              if (p != pages.selectedItem)  {
                 assert.equal(getComputedStyle(p).display, 'none')
                 assert.equal(p.clientHeight, 0)
                 assert.equal(p.offsetHeight, 0)

--- a/test/nested.html
+++ b/test/nested.html
@@ -48,14 +48,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var pages;
 
         suite('defaults', function() {
-          setup(function(done) {
-            pages = fixture('nested');
-            window.addEventListener('WebComponentsReady', function onReady() {
-              window.removeEventListener('WebComponentsReady', onReady);
-              done();
-            });
-          });
-
           test('selected item is display:block and all others are display:none', function() {
             pages.childNodes.forEach(function(p) {
               if (p.classList.contains('iron-selected')) {

--- a/test/nested.html
+++ b/test/nested.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="./nested-pages.html">
     

--- a/test/nested.html
+++ b/test/nested.html
@@ -50,10 +50,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           test('selected item is display:block and all others are display:none', function(done) {
             Polymer.Base.async(function() {
+              var p = pages.selectedItem;
+              assert.equal(getComputedStyle(p).display, 'block');
+              assert.isAbove(p.clientHeight, 0);
+              assert.isAbove(p.offsetHeight, 0);
+              assert.isAbove(p.scrollHeight, 0);
               pages.items.forEach(function(p) {
                 if (p != pages.selectedItem)  {
+                  assert.equal(getComputedStyle(p).display, 'none');
+                  assert.equal(p.clientHeight, 0);
+                  assert.equal(p.offsetHeight, 0);
+                  assert.equal(p.scrollHeight, 0);
                 }
               });
+              done();
             }, 1);
           });
         });

--- a/test/nested.html
+++ b/test/nested.html
@@ -48,20 +48,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             });
           });
 
-          test('selected item is display:block and all others are display:none', function() {
-            var p = pages.selectedItem
-            assert.equal(getComputedStyle(p).display, 'block')
-            assert.isAbove(p.clientHeight, 0)
-            assert.isAbove(p.offsetHeight, 0)
-            assert.isAbove(p.scrollHeight, 0)
-            pages.items.forEach(function(p) {
-              if (p != pages.selectedItem)  {
-                assert.equal(getComputedStyle(p).display, 'none')
-                assert.equal(p.clientHeight, 0)
-                assert.equal(p.offsetHeight, 0)
-                assert.equal(p.scrollHeight, 0)
-              }
-            });
+          test('selected item is display:block and all others are display:none', function(done) {
+            Polymer.Base.async(function() {
+              pages.items.forEach(function(p) {
+                if (p != pages.selectedItem)  {
+                }
+              });
+            }, 1);
           });
         });
       });

--- a/test/nested.html
+++ b/test/nested.html
@@ -39,7 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('nested', function() {
         var pages;
         
-        suite('set the selected attribute', function() {
+        suite('0 is selected', function() {
           setup(function(done) {
             pages = fixture('nested');
             pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
@@ -49,9 +49,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
           test('selected item is display:block and all others are display:none', function() {
-            for (i = 0; i < pages.children.length; i++) {
-              p = pages.children[i]
-              if (p.classList.contains('iron-selected')) {
+            pages.items.forEach(function(p) {
+              if (p == pages.selectedItem) {
                 assert.equal(getComputedStyle(p).display, 'block')
                 assert.isAbove(p.clientHeight, 0)
                 assert.isAbove(p.offsetHeight, 0)
@@ -62,10 +61,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 assert.equal(p.offsetHeight, 0)
                 assert.equal(p.scrollHeight, 0)
               }
-            }
+            });
           });
         });
-
       });
 
     </script>

--- a/test/nested.html
+++ b/test/nested.html
@@ -54,7 +54,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
           test('selected item is display:block and all others are display:none', function() {
-            pages.children.forEach(function(p) {
+            for (i = 0; i < pages.children.length; i++) {
+              var p = pages.children[i]
               if (p.classList.contains('iron-selected')) {
                 assert.equal(getComputedStyle(p).display, 'block')
                 assert.isAbove(p.clientHeight, 0)

--- a/test/nested.html
+++ b/test/nested.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
   <head>
 
-    <title>iron-pages-basic</title>
+    <title>iron-pages-nested</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
@@ -31,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </dom-module>
 
-    <test-fixture id="basic">
+    <test-fixture id="nested">
       <template>
         <nested-pages>
           <div id="page0">Page 0</div>
@@ -44,12 +44,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
 
-      suite('basic', function() {
+      suite('nested', function() {
         var pages;
 
         suite('defaults', function() {
           setup(function(done) {
-            pages = fixture('basic');
+            pages = fixture('nested');
             pages.addEventListener('iron-items-changed', function onIronItemsChanged() {
               pages.removeEventListener('iron-items-changed', onIronItemsChanged);
               done();
@@ -103,6 +103,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           test('selected item is display:block and all others are display:none', function() {
             pages.items.forEach(function(p) {
               assert.equal(getComputedStyle(p).display, p == pages.selectedItem ? 'block' : 'none');
+              if (p == pages.selectedItem) {
+                assert.isAbove(p.clientHeight, 0)
+                assert.isAbove(p.offsetHeight, 0)
+                assert.isAbove(p.scrollHeight, 0)
+              }
             });
           });
         });

--- a/test/nested.html
+++ b/test/nested.html
@@ -18,33 +18,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <link rel="import" href="../iron-pages.html">
+    <link rel="import" href="./nested-pages.html">
     
   </head>
   <body>
-    <dom-module id="nested-pages">
-      <template>
-        <h1>header</h1>
-        <iron-pages selected="[[selected]]" on-iron-items-changed="refire">
-          <slot></slot>
-        </iron-pages>
-      </template>
-      <script>
-      window.addEventListener('HTMLImportsLoaded', function(e) {  
-        Polymer({
-          is: 'nested-pages',
-          properties: {
-            selected: {
-              type: Number,
-            },
-          },
-          refire: function(e, detail) {
-            this.fire('iron-items-changed', e)
-          }
-        });
-      });
-      </script>
-    </dom-module>
 
     <test-fixture id="nested">
       <template>

--- a/test/nested.html
+++ b/test/nested.html
@@ -30,6 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </iron-pages>
       </template>
       <script>
+      window.addEventListener('HTMLImportsLoaded', function(e) {  
         Polymer({
           is: 'nested-pages',
           properties: {
@@ -41,6 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this.fire('iron-items-changed', e)
           }
         });
+      });
       </script>
     </dom-module>
 

--- a/test/nested.html
+++ b/test/nested.html
@@ -80,7 +80,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 assert.isAbove(p.scrollHeight, 0)
               } else {
                 assert.equal(getComputedStyle(p).display, 'none')
-                assert.equaql(p.clientHeight, 0)
+                assert.equal(p.clientHeight, 0)
                 assert.equal(p.offsetHeight, 0)
                 assert.equal(p.scrollHeight, 0)
               }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -27,12 +27,6 @@
           "platform":     "OS X 10.11",
           "version":      "9"
         },
-        
-        {
-          "browserName":  "chrome",
-          "platform":     "Linux",
-          "version":      "dev"
-        },
         {
           "browserName":  "chrome",
           "platform":     "Windows 10",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,55 @@
+{
+  "plugins": {
+    "sauce": {
+      "browsers": [
+        {
+          "browserName":  "microsoftedge",
+          "platform":     "Windows 10",
+          "version":      ""
+        },
+        {
+          "browserName":  "internet explorer",
+          "platform":     "Windows 8.1",
+          "version":      "11"
+        },
+        {
+          "browserName":  "safari",
+          "platform":     "OS X 10.12",
+          "version":      "11"
+        },
+        {
+          "browserName":  "safari",
+          "platform":     "OS X 10.11",
+          "version":      "10"
+        },
+        {
+          "browserName":  "safari",
+          "platform":     "OS X 10.11",
+          "version":      "9"
+        },
+        
+        {
+          "browserName":  "chrome",
+          "platform":     "Linux",
+          "version":      "dev"
+        },
+        {
+          "browserName":  "chrome",
+          "platform":     "Windows 10",
+          "version":      "beta"
+        },
+        {
+          "browserName":  "chrome",
+          "platform":     "Windows 10",
+          "version":      ""
+        },
+
+        {
+          "browserName":  "firefox",
+          "platform":     "Windows 10",
+          "version":      ""
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The issue seems to be that Safari implements slot tags as having display: content. When you put a slot inside an iron-pages, it gets display: none !important, which causes Safari not to display the nodes that should be distributed into it.